### PR TITLE
Create GVT-VIVO

### DIFF
--- a/GVT-VIVO
+++ b/GVT-VIVO
@@ -1,0 +1,7 @@
+Roteadores Arcadyan disponibilizados principalmente pela VIVO / GVT utilizam como nome padrão GVT-XXXX ou VIVO-XXXX
+XXXX = 4 últimos dígitos do MAC
+A WPA2 padrão desses roteadores é o S/N 
+
+Ideia: entender como o serial number dos roteadores arcadyan Modelo VRV7006AW22-A-GR são gerados.
+Objetivo: através do entendimento do S/N gerar uma tabela e anexar ao software
+


### PR DESCRIPTION
Roteadores Arcadyan disponibilizados principalmente pela VIVO / GVT utilizam como nome padrão GVT-XXXX ou VIVO-XXXX
XXXX = 4 últimos dígitos do MAC
A WPA2 padrão desses roteadores é o S/N .

Ideia: entender como o serial number dos roteadores arcadyan Modelo VRV7006AW22-A-GR são gerados.
Objetivo: através do entendimento do S/N gerar uma tabela e anexar ao software.
Update: O modelo VRV7006AW22-A-GR possui um padrão observado:
As 4 primeiras posições da senha vão de J400 à J653.
J4 - J6 = ano de fabricação
00 - 53 = a semana da fabricação
Os outros 6 componentes da senha são números, encurtando bastante uma possível wordlist.