### PR TITLE
Fixed OSx byte error at command scan.split()

### DIFF
--- a/dpwo.py
+++ b/dpwo.py
@@ -46,7 +46,7 @@ class NETOwner():
             scan = subprocess.check_output([self.airport, "scan"]).decode()
             # scan the area for wifi
         scan = scan.encode('ascii','ignore')
-        scan = scan.split("\n")
+        scan = scan.decode().split("\n")
 
         for wifi in scan:
             obj = str.split(wifi)


### PR DESCRIPTION
When executing the DPWO.py on OSx 10.14.6, I would get the following error:

`bytes-like object is required, not 'str'`

Adding the method "decode()" before the split method fixed the problem.